### PR TITLE
Add apic and managementdbupgrade outputs

### DIFF
--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -588,7 +588,7 @@ for NAMESPACE in $NAMESPACE_LIST; do
     mkdir -p $K8S_NAMESPACES_STS_DESCRIBE_DATA
 
     #grab cluster configuration, equivalent to "apiconnect-up.yml" which now resides in cluster
-    CLUSTER_LIST=(ManagementCluster ManagementBackup ManagementRestore AnalyticsCluster PortalCluster GatewayCluster)
+    CLUSTER_LIST=(apic ManagementCluster ManagementBackup ManagementRestore ManagamentDBUpgrade AnalyticsCluster PortalCluster GatewayCluster)
     for cluster in ${CLUSTER_LIST[@]}; do
         OUTPUT=`kubectl get -n $NAMESPACE $cluster 2>/dev/null`
         if [[ $? -eq 0 && ${#OUTPUT} -gt 0 ]]; then


### PR DESCRIPTION
1. `kubectl get apic` this command provides an output of all custom resources controlled by APIConnect 

Example output:

```
kubectl get apic
NAME                                                         STATUS   ID                 CLUSTER   TYPE   CR TYPE   AGE
managementbackup.management.apiconnect.ibm.com/m1-30f0173f   Ready    20210112-193933F   m1        full   record    47h

NAME                                                            STATUS     MESSAGE                                                     AGE
managementdbupgrade.management.apiconnect.ibm.com/m1-up-prssw   Complete   Fresh install is Complete (DB Schema/data are up-to-date)   47h

NAME                                                 READY   STATUS    VERSION        RECONCILED VERSION   AGE
managementcluster.management.apiconnect.ibm.com/m1   16/16   Running   10.0.1.1-eus   10.0.1.1-1423-eus    47h
```

2. `kubectl get ManagementDBUpgrade` - This command provides information about management db upgrades 

Example:

```
kubectl get ManagementDBUpgrade
NAME          STATUS     MESSAGE                                                     AGE
m1-up-prssw   Complete   Fresh install is Complete (DB Schema/data are up-to-date)   47h
```