### PR TITLE
Fix analytics

### DIFF
--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -918,6 +918,9 @@ for NAMESPACE in $NAMESPACE_LIST; do
         echo "$OUTPUT" > "${K8S_NAMESPACES_POD_DATA}/pods.out"
         while read line; do
             pod=`echo "$line" | awk -F ' ' '{print $1}'`
+            if [[ "$pod" == "NAME" ]]; then
+                continue
+            fi
             ready=`echo "$line" | awk -F ' ' '{print $2}' | awk -F'/' '{ print ($1==$2) ? "1" : "0" }'`
             status=`echo "$line" | awk -F ' ' '{print $3}'`
             node=`echo "$line" | awk -F ' ' '{print $7}'`

--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -1206,17 +1206,17 @@ for NAMESPACE in $NAMESPACE_LIST; do
                 mkdir -p $ANALYTICS_DIAGNOSTIC_DATA
 
                 if [[ "$pod" == *"storage-"* ]]; then
-                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -k --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_cluster/health?pretty"`
+                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -ks --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_cluster/health?pretty"`
                     echo "$OUTPUT1" >"${ANALYTICS_DIAGNOSTIC_DATA}/curl-cluster_health.out"
-                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -k --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_cat/nodes?v"`
+                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -ks --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_cat/nodes?v"`
                     echo "$OUTPUT1" >"${ANALYTICS_DIAGNOSTIC_DATA}/curl-cat_nodes.out"
-                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -k --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_cat/indices?v"`
+                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -ks --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_cat/indices?v"`
                     echo "$OUTPUT1" >"${ANALYTICS_DIAGNOSTIC_DATA}/curl-cat_indices.out"
-                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -k --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_cat/shards?v"`
+                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -ks --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_cat/shards?v"`
                     echo "$OUTPUT1" >"${ANALYTICS_DIAGNOSTIC_DATA}/curl-cat_shards.out"
-                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -k --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_alias?pretty"`
+                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -ks --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_alias?pretty"`
                     echo "$OUTPUT1" >"${ANALYTICS_DIAGNOSTIC_DATA}/curl-alias.out"
-                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -k --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_cluster/allocation/explain?pretty"`
+                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -ks --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_cluster/allocation/explain?pretty"`
                     echo "$OUTPUT1" >"${ANALYTICS_DIAGNOSTIC_DATA}/curl-cluster_allocation_explain.out"
                 elif [[ "$pod" == *"ingestion"* ]]; then
                     OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -s "localhost:9600/_node/stats?pretty"`

--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -1206,17 +1206,17 @@ for NAMESPACE in $NAMESPACE_LIST; do
                 mkdir -p $ANALYTICS_DIAGNOSTIC_DATA
 
                 if [[ "$pod" == *"storage-"* ]]; then
-                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl_es -s "_cluster/health?pretty"`
+                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -k --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_cluster/health?pretty"`
                     echo "$OUTPUT1" >"${ANALYTICS_DIAGNOSTIC_DATA}/curl-cluster_health.out"
-                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl_es -s "_cat/nodes?v"`
+                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -k --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_cat/nodes?v"`
                     echo "$OUTPUT1" >"${ANALYTICS_DIAGNOSTIC_DATA}/curl-cat_nodes.out"
-                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl_es -s "_cat/indices?v"`
+                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -k --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_cat/indices?v"`
                     echo "$OUTPUT1" >"${ANALYTICS_DIAGNOSTIC_DATA}/curl-cat_indices.out"
-                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl_es -s "_cat/shards?v"`
+                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -k --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_cat/shards?v"`
                     echo "$OUTPUT1" >"${ANALYTICS_DIAGNOSTIC_DATA}/curl-cat_shards.out"
-                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl_es -s "_alias?pretty"`
+                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -k --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_alias?pretty"`
                     echo "$OUTPUT1" >"${ANALYTICS_DIAGNOSTIC_DATA}/curl-alias.out"
-                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl_es -s "_cluster/allocation/explain?pretty"`
+                    OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -k --cert /etc/velox/certs/client/tls.crt --key /etc/velox/certs/client/tls.key "https://localhost:9200/_cluster/allocation/explain?pretty"`
                     echo "$OUTPUT1" >"${ANALYTICS_DIAGNOSTIC_DATA}/curl-cluster_allocation_explain.out"
                 elif [[ "$pod" == *"ingestion"* ]]; then
                     OUTPUT1=`kubectl exec -n $NAMESPACE $pod -- curl -s "localhost:9600/_node/stats?pretty"`


### PR DESCRIPTION
This fixes two issues.
1. On OVA, if the Analytics subsystem name is too long, the generated pod names contain a truncated form of that subsystem name. Consequently checking pod names against `*"${SUBSYS_ANALYTICS}"*` results in pods not being found. The fix uses labels to find the pods.
2. In APIC versions >= v10.0.5, `curl_es` is no longer shipped. This is used when downloading details from the Analytics pods. The fix uses `curl` instead of `curl_es`.