### PR TITLE
Fixing the pod not found Error

### DIFF
--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -1137,7 +1137,7 @@ for NAMESPACE in $NAMESPACE_LIST; do
                     esac
 
                     # Following is to fix the case where analytics instance name is truncated.
-                    INSTANCE_LABEL=`kubectl get pod -n $NAMESPACE -o jsonpath='{.metadata.labels.app\.kubernetes\.io\/instance}' $pod` &>/dev/null
+                    INSTANCE_LABEL=`kubectl get pod -n $NAMESPACE -o jsonpath='{.metadata.labels.app\.kubernetes\.io\/instance}' $pod 2>/dev/null`
                     if [[ $INSTANCE_LABEL == $SUBSYS_ANALYTICS ]]; then
                         SUBFOLDER="analytics"
                         subAnalytics=$SUBSYS_ANALYTICS


### PR DESCRIPTION
- Added get pod -n $NAMESPACE to fix the error messages generated from the pods when running the postmortem script.