### PR TITLE
 Add request timeout to handle crunchy pods hanging

### DIFF
--- a/crunchy_gather.py
+++ b/crunchy_gather.py
@@ -332,7 +332,7 @@ def collect_pg_pod_details():
                                             container), "ab+") as file_pointer:
                 for command in (CONTAINER_COMMANDS['all'] +
                                 CONTAINER_COMMANDS[container]):
-                    cmd = (OPT.kube_cli + " exec -it {} -c {} {} -- "
+                    cmd = (OPT.kube_cli + " exec -it --pod-running-timeout=1m0s {} -c {} {} -- "
                            "/bin/bash -c '{}'"
                            .format(get_namespace_argument(),
                                    container, pod, command))
@@ -375,7 +375,7 @@ def collect_pg_logs():
         os.makedirs(tgt_file)
         # print("OPT.pg_logs_count:  ", OPT.pg_logs_count)
         cmd = (OPT.kube_cli +
-               " exec -it {} -c database {} -- /bin/bash -c"
+               " exec -it --pod-running-timeout=1m0s {} -c database {} -- /bin/bash -c"
                " 'ls -1dt /pgdata/*/pglogs/* | head -{}'"
                .format(get_namespace_argument(), pod, OPT.pg_logs_count))
         # print(cmd)


### PR DESCRIPTION
Refs: https://github.ibm.com/velox/platform/issues/8286

- I was unable to replicate the client scenario but added a potential fix given the known information. Instead of adding --request-timeout command I added --pod-running-timeout which waits the chosen length of time until at least one pod is running, in this case 1 minute. While comparing the files generated from before and after adding the new command I did notice that some of the files had been extended but none of the information was missing there was just more activity to report I think due to the extension of running time from the command. I found this particularly within the events log and some of the pod logs.