### PR TITLE
Include version of tool

### DIFF
--- a/.github/workflows/automaticVersionUpdate.yml
+++ b/.github/workflows/automaticVersionUpdate.yml
@@ -1,0 +1,21 @@
+name: Hash of last commit 
+
+on: 
+  push 
+jobs:
+  thisOne: 
+    runs-on: macos-latest
+  
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          input="./generate_postmortem.sh"
+          COMM=`git rev-parse HEAD`
+          CURRENTCOMMIT="PMVERSION='$COMM'"
+          sed -i -e "s|PMVERSION=.*|$CURRENTCOMMIT|g" ${GITHUB_WORKSPACE}/generate_postmortem.sh
+          git config --global user.name "actionbot"
+          git config --global user.email "githubactions" 
+          git commit -a -m "Automatic update of version"
+          git push
+          
+        shell: bash

--- a/.github/workflows/automaticVersionUpdate.yml
+++ b/.github/workflows/automaticVersionUpdate.yml
@@ -11,8 +11,8 @@ jobs:
       - run: |
           input="./generate_postmortem.sh"
           COMM=`git rev-parse HEAD`
-          CURRENTCOMMIT="PMVERSION='$COMM'"
-          sed -i -e "s|PMVERSION=.*|$CURRENTCOMMIT|g" ${GITHUB_WORKSPACE}/generate_postmortem.sh
+          CURRENTCOMMIT="PMCOMMIT='$COMM'"
+          sed -i -e "s|PMCOMMIT=.*|$CURRENTCOMMIT|g" ${GITHUB_WORKSPACE}/generate_postmortem.sh
           git config --global user.name "actionbot"
           git config --global user.email "githubactions" 
           git commit -a -m "Automatic update of version"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -9,7 +9,7 @@
 #
 
 #parse passed arguments
-PMCOMMIT='97072fdc96519586066ca541f2dcb9044c4eb804'
+PMCOMMIT='33f111daa2f772e18d43246510440212de0c03f7'
 PMCOMMITURL="https://github.com/ibm-apiconnect/v10-postmortem/commit/$PMCOMMIT"
 echo "Postmortem Version: $PMCOMMITURL"
 

--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -11,7 +11,6 @@
 #parse passed arguments
 PMCOMMIT='33f111daa2f772e18d43246510440212de0c03f7'
 PMCOMMITURL="https://github.com/ibm-apiconnect/v10-postmortem/commit/$PMCOMMIT"
-echo "Postmortem Version: $PMCOMMITURL"
 
 for switch in $@; do
     case $switch in
@@ -150,6 +149,9 @@ for switch in $@; do
             ;;
     esac
 done
+
+#Printing Postmortem Version
+echo "Postmortem Version: $PMCOMMITURL"
 
 if [[ -z "$LOG_LIMIT" ]]; then
     LOG_LIMIT=""

--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -9,6 +9,10 @@
 #
 
 #parse passed arguments
+PMVERSION='6f749d0813bf8f085df00a1de23119904d4f8137'
+BUILDINGLINK="https://github.com/ibm-apiconnect/v10-postmortem/commit/$PMVERSION"
+echo "Postmortem Version: $BUILDINGLINK"
+
 for switch in $@; do
     case $switch in
         *"-h"*|*"--help"*)
@@ -38,6 +42,7 @@ for switch in $@; do
             echo -e ""
             echo -e "--debug:                 Set to enable verbose logging."
             echo -e ""
+            echo -e "--version:               Show postmortem version"
             exit 0
             ;;
         *"--debug"*)
@@ -133,6 +138,10 @@ for switch in $@; do
                 exit 1
             fi
             chmod +x $SCRIPT_LOCATION
+            ;;
+        *"--version"*)
+            echo "Postmortem Version: $BUILDINGLINK"
+            exit 1
             ;;
         *)
             if [[ -z "$DEBUG_SET" ]]; then
@@ -477,6 +486,9 @@ mkdir -p $K8S_CLUSTER_MUTATINGWEBHOOK_YAML_OUTPUT
 
 #grab kubernetes version
 kubectl version 1>"${K8S_VERSION}/kubectl.version" 2>/dev/null
+
+#grab postmortem version 
+echo "Postmortem Version: $BUILDINGLINK" 1>"${K8S_VERSION}/postmortem.version" 2>/dev/null
 
 #----------------------------------- collect cluster specific data ------------------------------------
 #node

--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -9,9 +9,9 @@
 #
 
 #parse passed arguments
-PMVERSION='97072fdc96519586066ca541f2dcb9044c4eb804'
-BUILDINGLINK="https://github.com/ibm-apiconnect/v10-postmortem/commit/$PMVERSION"
-echo "Postmortem Version: $BUILDINGLINK"
+PMCOMMIT='97072fdc96519586066ca541f2dcb9044c4eb804'
+PMCOMMITURL="https://github.com/ibm-apiconnect/v10-postmortem/commit/$PMCOMMIT"
+echo "Postmortem Version: $PMCOMMITURL"
 
 for switch in $@; do
     case $switch in
@@ -140,8 +140,8 @@ for switch in $@; do
             chmod +x $SCRIPT_LOCATION
             ;;
         *"--version"*)
-            echo "Postmortem Version: $BUILDINGLINK"
-            exit 1
+            echo "Postmortem Version: $PMCOMMITURL"
+            exit 0
             ;;
         *)
             if [[ -z "$DEBUG_SET" ]]; then
@@ -488,7 +488,7 @@ mkdir -p $K8S_CLUSTER_MUTATINGWEBHOOK_YAML_OUTPUT
 kubectl version 1>"${K8S_VERSION}/kubectl.version" 2>/dev/null
 
 #grab postmortem version 
-echo "Postmortem Version: $BUILDINGLINK" 1>"${K8S_VERSION}/postmortem.version" 2>/dev/null
+echo "Postmortem Version: $PMCOMMITURL" 1>"${K8S_VERSION}/postmortem.version" 2>/dev/null
 
 #----------------------------------- collect cluster specific data ------------------------------------
 #node

--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -9,7 +9,7 @@
 #
 
 #parse passed arguments
-PMVERSION='6f749d0813bf8f085df00a1de23119904d4f8137'
+PMVERSION='97072fdc96519586066ca541f2dcb9044c4eb804'
 BUILDINGLINK="https://github.com/ibm-apiconnect/v10-postmortem/commit/$PMVERSION"
 echo "Postmortem Version: $BUILDINGLINK"
 

--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -9,7 +9,7 @@
 #
 
 #parse passed arguments
-PMCOMMIT='33f111daa2f772e18d43246510440212de0c03f7'
+PMCOMMIT='dee6a178e1eca300c155fbdcc7d7494634b4103b'
 PMCOMMITURL="https://github.com/ibm-apiconnect/v10-postmortem/commit/$PMCOMMIT"
 
 for switch in $@; do


### PR DESCRIPTION
Refs: https://github.ibm.com/velox/platform/issues/6572

- Added variable to hold the hash that is associated with the last commit so a Github workflow can automatically update the hash after each push
- Added variable to create a link by using the commit hash
- Added --version option to display the commit link aka the most recent version of the PM script
- Added a file that holds the most recent version of the script
- Added workflow to search and replace PMVERSION variable within the generate_postmortem script