### PR TITLE
Include contents of ImageContentSourcePolicy when available

### DIFF
--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -665,9 +665,9 @@ if [[ $? -eq 0 && ${#OUTPUT} -gt 0 ]]; then
 fi
 
 #Get ImageContentSourcePolicy
-OUTPUT=`$KUBECTL get imagecontentsourcepolicy -A -oyaml 2>/dev/null`
+OUTPUT=`$KUBECTL get imagecontentsourcepolicy -oyaml 2>/dev/null`
 if [[ $? -eq 0 && ${#OUTPUT} -gt 0 ]]; then 
-    echo "$OUTPUT" > "${K8S_CLUSTER_LIST_DATA}/icsp.out"
+    echo "$OUTPUT" > "${K8S_CLUSTER_LIST_DATA}/icsp.yaml"
 fi
 
 #------------------------------------------------------------------------------------------------------

--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -664,6 +664,12 @@ if [[ $? -eq 0 && ${#OUTPUT} -gt 0 ]]; then
     echo "$OUTPUT" > "${K8S_CLUSTER_LIST_DATA}/scc.out"
 fi
 
+#Get ImageContentSourcePolicy
+OUTPUT=`$KUBECTL get imagecontentsourcepolicy -A -oyaml 2>/dev/null`
+if [[ $? -eq 0 && ${#OUTPUT} -gt 0 ]]; then 
+    echo "$OUTPUT" > "${K8S_CLUSTER_LIST_DATA}/icsp.out"
+fi
+
 #------------------------------------------------------------------------------------------------------
 
 #---------------------------------- collect namespace specific data -----------------------------------


### PR DESCRIPTION
Refs: https://github.ibm.com/velox/platform/issues/8516

- Extra information is captured under Kubernetes/cluster/lists/icsp.out
- If the command doesn't exit with zero then the file is never created and therefore not saved.