### PR TITLE
Include output of kubectl api-resources

### DIFF
--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -671,7 +671,7 @@ if [[ $? -eq 0 && ${#OUTPUT} -gt 0 ]]; then
 fi
 
 #Get api-resources
-OUTPUT=`$KUBECTL api-resources 2>/dev/null`
+OUTPUT=`$KUBECTL api-resources &> "${K8S_CLUSTER_LIST_DATA}/api-resources.out"`
 if [[ $? -eq 0 && ${#OUTPUT} -gt 0 ]]; then 
     echo "$OUTPUT" > "${K8S_CLUSTER_LIST_DATA}/api-resources.out"
 fi

--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -671,10 +671,7 @@ if [[ $? -eq 0 && ${#OUTPUT} -gt 0 ]]; then
 fi
 
 #Get api-resources
-OUTPUT=`$KUBECTL api-resources &> "${K8S_CLUSTER_LIST_DATA}/api-resources.out"`
-if [[ $? -eq 0 && ${#OUTPUT} -gt 0 ]]; then 
-    echo "$OUTPUT" > "${K8S_CLUSTER_LIST_DATA}/api-resources.out"
-fi
+$KUBECTL api-resources &> "${K8S_CLUSTER_LIST_DATA}/api-resources.out"
 #------------------------------------------------------------------------------------------------------
 
 #---------------------------------- collect namespace specific data -----------------------------------

--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -670,6 +670,11 @@ if [[ $? -eq 0 && ${#OUTPUT} -gt 0 ]]; then
     echo "$OUTPUT" > "${K8S_CLUSTER_LIST_DATA}/icsp.yaml"
 fi
 
+#Get api-resources
+OUTPUT=`$KUBECTL api-resources 2>/dev/null`
+if [[ $? -eq 0 && ${#OUTPUT} -gt 0 ]]; then 
+    echo "$OUTPUT" > "${K8S_CLUSTER_LIST_DATA}/api-resources.out"
+fi
 #------------------------------------------------------------------------------------------------------
 
 #---------------------------------- collect namespace specific data -----------------------------------


### PR DESCRIPTION
Refs: https://github.ibm.com/velox/platform/issues/8529

- Added section to include kubectl api-resources
- Extra information is captured under kubernetes/cluster/lists
- If the command doesn't exit with zero then the file is never created and therefore is not saved