### PR TITLE
Warn if postmortem scripts are out of date

### DIFF
--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -164,6 +164,7 @@ for switch in $@; do
                 echo -e "Unable to locate script [crunchy_gather.py] in current directory.  Download from GitHub repository.  Exiting..."
                 exit 1
             fi
+            warn_if_script_is_not_latest crunchy_gather.py https://raw.githubusercontent.com/ibm-apiconnect/v10-postmortem/master/crunchy_gather.py
             chmod +x $SCRIPT_LOCATION
             ;;
         *"--collect-edb"*)
@@ -173,6 +174,7 @@ for switch in $@; do
                 echo -e "Unable to locate script [edb_mustgather.sh] in current directory.  Download from GitHub repository.  Exiting..."
                 exit 1
             fi
+            warn_if_script_is_not_latest edb_mustgather.sh https://raw.githubusercontent.com/ibm-apiconnect/v10-postmortem/master/edb_mustgather.sh
             chmod +x $SCRIPT_LOCATION
             ;;
         *"--version"*)
@@ -1028,13 +1030,11 @@ for NAMESPACE in $NAMESPACE_LIST; do
 
     #grab crunchy mustgather
     if [[ $COLLECT_CRUNCHY -eq 1 && "$NAMESPACE" != "kube-system" ]]; then
-        warn_if_script_is_not_latest crunchy_gather.py https://raw.githubusercontent.com/ibm-apiconnect/v10-postmortem/master/crunchy_gather.py
         $CURRENT_PATH/crunchy_gather.py -n $NAMESPACE -l 5 -c $KUBECTL -o $K8S_NAMESPACES_CRUNCHY_DATA &> "${K8S_NAMESPACES_CRUNCHY_DATA}/crunchy-collect.log"
     fi
 
     #grab edb mustgather
     if [[ $COLLECT_EDB -eq 1 && "$NAMESPACE" != "kube-system" ]]; then
-        warn_if_script_is_not_latest edb_mustgather.sh https://raw.githubusercontent.com/ibm-apiconnect/v10-postmortem/master/edb_mustgather.sh
         $CURRENT_PATH/edb_mustgather.sh $NAMESPACE $K8S_NAMESPACES_EDB &> "${K8S_NAMESPACES_EDB}/edb-collect.log"
     fi
 


### PR DESCRIPTION
Hash the latest postmortem scripts and compare with the local one to warn the user if they have an out of date script. This should hopefully push users towards using the latest postmortem scripts.

e.g.
```
❯ ./generate_postmortem.sh --specific-namespace=bhav 
Postmortem Version: 13, Date: Tue Oct 17 22:48:14 UTC 2023, URL: https://github.com/ibm-apiconnect/v10-postmortem/blob/001e835045cfddd3b49aa666edc60c38320f9cf6/generate_postmortem.sh
using [oc] command for cluster cli
---------------------------------------------------------
NOTE: There is a newer version of generate_postmortem.sh available. Please download the latest postmortem script from https://github.com/ibm-apiconnect/v10-postmortem so that up-to-date information is gathered.
WARNING: If you don't use the latest generate_postmortem.sh script, IBM support may ask you to download the latest generate_postmortem.sh script and run it again.
---------------------------------------------------------
Generating postmortem, please wait...
```