### PR TITLE
Include output of apicops health checks

### DIFF
--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -854,9 +854,7 @@ else
             echo "adding to PATH"
             HOLDING_PWD=`pwd`
             export PATH=$PATH:"$HOLDING_PWD" 
-            echo "$PATH"
-            OUTPUT=`apicops upgrade:pg-health-check 2>/dev/null`
-            echo "$OUTPUT"
+            #Error happening here, it never gets to the commands after this case
         else
             #if they dont match, based on the OS download the latest version
             echo "needs update" 

--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -832,7 +832,7 @@ else
     OUTPUT=`apicops upgrade:check-postgres-leader 2>/dev/null`
     if [[ $? -eq 0 && ${#OUTPUT} -gt 0 ]]; then
        echo "$OUTPUT" > "${K8S_CLUSTER_APICOPS_HEALTH_CHECK}/upgrade:check-postgres-leader.out"
-   fi
+    fi
 fi
 #------------------------------------------------------------------------------------------------------
 

--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -808,9 +808,7 @@ fi
 #Get api-resources
 $KUBECTL api-resources &> "${K8S_CLUSTER_LIST_DATA}/api-resources.out"
 
-#--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-#APICOPS HEALTH CHECK DATA 
-
+#----------------------------------- collect apicops specific data ------------------------------------
 download_latest_apicops_macOS(){
     curl -L -o apicops https://github.com/ibm-apiconnect/apicops/releases/download/v0.10.66/apicops-v10-macos
     chmod +x apicops
@@ -833,44 +831,39 @@ check_OS_download_apicops(){
     fi
 }
 
-
-#Detecting the users operating system 
-#add check for OS, and set a variable so it can be used again later to simplify things
 OS_TYPE=`uname`
 APICOPS_WHICH_COMMAND=`which apicops`
 APICOPS_CURRENT_DIRECTORY="`pwd`/apicops"
 REMOTE_APICOPS_CHECKSUM_MACOS=$(curl -sL https://github.com/ibm-apiconnect/apicops/releases/download/v0.10.66/apicops-v10-macos|sha256sum | cut -d' ' -f1)
 REMOTE_APICOPS_CHECKSUM_LINUX=$(curl -sL https://github.com/ibm-apiconnect/apicops/releases/download/v0.10.66/apicops-v10-linux|sha256sum | cut -d' ' -f1)
-if [[ ! ${#APICOPS_WHICH_COMMAND} -gt 0 ]] && [[ ! -e $APICOPS_CURRENT_DIRECTORY ]]; then
-    echo -e "Unable to locate the command apicops in the path. Downloading From: https://github.com/ibm-apiconnect/apicops?tab=readme-ov-file"
+if [[ -z "$APICOPS_WHICH_COMMAND" ]] && [[ ! -e $APICOPS_CURRENT_DIRECTORY ]]; then
+    echo -e "Unable to locate the command apicops in the PATH. Downloading From: https://github.com/ibm-apiconnect/apicops?tab=readme-ov-file"
     check_OS_download_apicops
 else 
     if [[ -e $APICOPS_CURRENT_DIRECTORY ]]; then
-        echo "found in the directory" 
-        echo "Checking to see if this is the most up to date version"
+        echo "Found within the current directory, checking to see if this is the most up to date version"
         LOCAL_APICOPS_CHECKSUM=$(sha256sum apicops | cut -d' ' -f1)
-        #change this to check for both OS systems
-        if [[ "$LOCAL_APICOPS_CHECKSUM" = "$REMOTE_APICOPS_CHECKSUM_MACOS" ]]; then 
-            echo "adding to PATH"
+        if [[ "$LOCAL_APICOPS_CHECKSUM" = "$REMOTE_APICOPS_CHECKSUM_MACOS" ]] || [[ "$LOCAL_APICOPS_CHECKSUM" = "$REMOTE_APICOPS_CHECKSUM_LINUX" ]]; then 
+            echo "Up to date: Adding to temporary PATH"
             HOLDING_PWD=`pwd`
             export PATH=$PATH:"$HOLDING_PWD" 
-            #Error happening here, it never gets to the commands after this case
         else
-            #if they dont match, based on the OS download the latest version
-            echo "needs update" 
-            check_OS_download_apicops
+            if [[ "$LOCAL_APICOPS_CHECKSUM" != "$REMOTE_APICOPS_CHECKSUM_MACOS" ]] && [[ "$LOCAL_APICOPS_CHECKSUM" != "$REMOTE_APICOPS_CHECKSUM_LINUX" ]]; then
+                echo "Updating apicops version" 
+                check_OS_download_apicops
+            fi
         fi
-    elif [[ ${#APICOPS_WHICH_COMMAND} -gt 0 ]]; then
-        echo "found via which command"
+    elif [[ ! -z "$APICOPS_WHICH_COMMAND" ]]; then
+        echo "Found at: $APICOPS_WHICH_COMMAND"
         LOCAL_APICOPS_CHECKSUM=$(sha256sum $APICOPS_WHICH_COMMAND | cut -d' ' -f1)
-        if [[ "$LOCAL_APICOPS_CHECKSUM" != "$REMOTE_APICOPS_CHECKSUM_MACOS" ]] && [[ "$LOCAL_APICOPS_CHECKSUM" != "$REMOTE_APICOPS_CHECKSUM_LINUX" ]]; then 
-            echo "needs update" 
+        if [[ "$LOCAL_APICOPS_CHECKSUM" != "$REMOTE_APICOPS_CHECKSUM_MACOS" ]] && [[ "$LOCAL_APICOPS_CHECKSUM" != "$REMOTE_APICOPS_CHECKSUM_LINUX" ]]; then  
+            echo "Updating apicops version" 
             check_OS_download_apicops
         fi
     fi
 fi
-if [[ ${#APICOPS_WHICH_COMMAND} -gt 0 ]]; then
-    echo "here"
+APICOPS_WHICH_COMMAND=`which apicops`
+if [[ ! -z "$APICOPS_WHICH_COMMAND" ]]; then
     OUTPUT=`apicops upgrade:pg-health-check 2>/dev/null`
     if [[ $? -eq 0 && ${#OUTPUT} -gt 0 ]]; then
         echo "$OUTPUT" > "${K8S_CLUSTER_APICOPS_HEALTH_CHECK}/upgrade:pg-health-check.out"

--- a/generate_postmortem.sh
+++ b/generate_postmortem.sh
@@ -809,15 +809,16 @@ fi
 $KUBECTL api-resources &> "${K8S_CLUSTER_LIST_DATA}/api-resources.out"
 
 #----------------------------------- collect apicops specific data ------------------------------------
+APICOPS_VERSION="v0.10.66"
 download_latest_apicops_macOS(){
-    curl -L -o apicops https://github.com/ibm-apiconnect/apicops/releases/download/v0.10.66/apicops-v10-macos
+    curl -L -o apicops https://github.com/ibm-apiconnect/apicops/releases/download/$APICOPS_VERSION/apicops-v10-macos
     chmod +x apicops
     HOLDING_PWD=`pwd`
     export PATH=$PATH:"$HOLDING_PWD"
 }
 
 download_latest_apicops_linux(){
-    curl -L -o apicops https://github.com/ibm-apiconnect/apicops/releases/download/v0.10.66/apicops-v10-linux
+    curl -L -o apicops https://github.com/ibm-apiconnect/apicops/releases/download/$APICOPS_VERSION/apicops-v10-linux
     chmod +x apicops
     HOLDING_PWD=`pwd`
     export PATH=$PATH:"$HOLDING_PWD"
@@ -834,8 +835,8 @@ check_OS_download_apicops(){
 OS_TYPE=`uname`
 APICOPS_WHICH_COMMAND=`which apicops`
 APICOPS_CURRENT_DIRECTORY="`pwd`/apicops"
-REMOTE_APICOPS_CHECKSUM_MACOS=$(curl -sL https://github.com/ibm-apiconnect/apicops/releases/download/v0.10.66/apicops-v10-macos|sha256sum | cut -d' ' -f1)
-REMOTE_APICOPS_CHECKSUM_LINUX=$(curl -sL https://github.com/ibm-apiconnect/apicops/releases/download/v0.10.66/apicops-v10-linux|sha256sum | cut -d' ' -f1)
+REMOTE_APICOPS_CHECKSUM_MACOS=$(curl -sL https://github.com/ibm-apiconnect/apicops/releases/download/$APICOPS_VERSION/apicops-v10-macos|sha256sum | cut -d' ' -f1)
+REMOTE_APICOPS_CHECKSUM_LINUX=$(curl -sL https://github.com/ibm-apiconnect/apicops/releases/download/$APICOPS_VERSION/apicops-v10-linux|sha256sum | cut -d' ' -f1)
 if [[ -z "$APICOPS_WHICH_COMMAND" ]] && [[ ! -e $APICOPS_CURRENT_DIRECTORY ]]; then
     echo -e "Unable to locate the command apicops in the PATH. Downloading From: https://github.com/ibm-apiconnect/apicops?tab=readme-ov-file"
     check_OS_download_apicops


### PR DESCRIPTION
Refs: https://github.ibm.com/velox/platform/issues/6571
- Added which apicops check to see if apicops is added to the users PATH
- If it is not found it will not run the apicops commands and will link to where the client can install the file
- If it is, run the following apicops commands: 
          apicops upgrade:pg-health-check 
          apicops upgrade:check-subsystem-status 
          apicops upgrade: stale-certs 
          apicops upgrade: check-pvc 
          apicops upgrade:check-postgres-leader
- Created directories to store the information from the commands.